### PR TITLE
Add http-server start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ npm test
 
 ## Servidor estático
 
-Si prefieres servir los archivos mediante un servidor local, ejecuta:
+Inicia un servidor local con:
 
 ```bash
-npx http-server # o npx serve
+npm start
 ```
 
 `index.html` está en la raíz del proyecto, por lo que al abrir `http://localhost:<puerto>` podrás ver la aplicación.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "http-server",
     "test": "jest"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add `start` command in package.json
- update README to use `npm start`

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68751759a6e08322af03f273fce51d1e